### PR TITLE
Enable use of `be_computed_by_function` in Opal

### DIFF
--- a/lib/mspec/matchers/be_computed_by_function.rb
+++ b/lib/mspec/matchers/be_computed_by_function.rb
@@ -18,7 +18,7 @@ class BeComputedByFunctionMatcher
   def function_call
     function_call = "#{@function}"
     unless @arguments.empty?
-      function_call << "(#{@arguments.map { |x| x.inspect }.join(", ")})"
+      function_call += "(#{@arguments.map { |x| x.inspect }.join(", ")})"
     end
     function_call
   end


### PR DESCRIPTION
Mspec’s use of `String#<<` in `BeComputedByFunctionMatcher` makes it
impossible to use  `be_computed_by_function` in Opal because Opal does
not support mutable strings. Fortunately `String#<<` is completely
unnecessary in this case, and the same effect can be accomplished by
string concatenation using `String#+`.
